### PR TITLE
Rename MASTER_KEY to REST_API_KEY

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -6,12 +6,12 @@ ParsePy
 Basic Usage
 -----------
 
-Let's get everything set up first. You'll need to give **ParsePy** your _Application Id_ and _Master Key_ (available from your Parse dashboard) in order to get access to your data.
+Let's get everything set up first. You'll need to give **ParsePy** your _Application Id_ and _REST API Key_ (available from your Parse dashboard) in order to get access to your data.
 
 ~~~~~ {python}
 >>> import ParsePy
 >>> ParsePy.APPLICATION_ID = "your application id"
->>> ParsePy.MASTER_KEY = "your master key here"
+>>> ParsePy.REST_API_KEY = "your REST API key here"
 ~~~~~
 
 To create a new object of the Parse class _GameScore_:

--- a/__init__.py
+++ b/__init__.py
@@ -22,7 +22,7 @@ import re
 API_ROOT = 'https://api.parse.com/1/classes'
 
 APPLICATION_ID = ''
-MASTER_KEY = ''
+REST_API_KEY = ''
 
 
 class ParseBinaryDataWrapper(str):
@@ -38,10 +38,10 @@ class ParseBase(object):
         request.add_header('Content-type', 'application/json')
 
         #auth_header =  "Basic %s" % base64.b64encode('%s:%s' %
-        #                            (APPLICATION_ID, MASTER_KEY))
+        #                            (APPLICATION_ID, REST_API_KEY))
         #request.add_header("Authorization", auth_header)
         request.add_header("X-Parse-Application-Id", APPLICATION_ID)
-        request.add_header("X-Parse-REST-API-Key", MASTER_KEY)
+        request.add_header("X-Parse-REST-API-Key", REST_API_KEY)
 
         request.get_method = lambda: http_verb
 

--- a/tests.py
+++ b/tests.py
@@ -15,7 +15,7 @@ except ImportError:
                       "with an example application to run tests")
 
 ParsePy.APPLICATION_ID = settings_local.APPLICATION_ID
-ParsePy.MASTER_KEY = settings_local.MASTER_KEY
+ParsePy.REST_API_KEY = settings_local.REST_API_KEY
 
 
 ### FUNCTIONS ###


### PR DESCRIPTION
The Master Key (a separate key on the Parse dashboard) returns a HTTP 401 Unauthorised error from Parse. I have replaced this with the REST API Key which I have tested and this works. 

This error may have been caused by an update in Parse where they have differentiated or changed the naming of their keys.
