### PR TITLE
Add master key header only if no user session is specified

### DIFF
--- a/parse_rest/connection.py
+++ b/parse_rest/connection.py
@@ -78,7 +78,8 @@ class ParseBase(object):
         request.add_header('X-Parse-Application-Id', app_id)
         request.add_header('X-Parse-REST-API-Key', rest_key)
 
-        if master_key: request.add_header('X-Parse-Master-Key', master_key)
+        if master_key and 'X-Parse-Session-Token' not in headers.keys():
+            request.add_header('X-Parse-Master-Key', master_key)
 
         request.get_method = lambda: http_verb
 


### PR DESCRIPTION
Hi,

I've added this check to avoid including master key if a user session is specified in the request header. By doing so, you're able to call a function as a user, and not as the master, even if you've initialized the application with your master key.

Ex:

``` python
user = User.login(username, password)
hello_func = Function("hello")
hello_func(extra_headers=user.session_header())
```

 It can be convenient when in your script you have to switch between master and simple users.

What do you think?
