### PR TITLE
Python3 support

### DIFF
--- a/parse_rest/connection.py
+++ b/parse_rest/connection.py
@@ -11,8 +11,15 @@
 #    You should have received a copy of the GNU General Public License
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import urllib2
-import urllib
+try:
+    from urllib2 import Request, urlopen, HTTPError
+    from urllib import urlencode
+except ImportError:
+    # is Python3
+    from urllib.request import Request, urlopen
+    from urllib.error import HTTPError
+    from urllib.parse import urlencode
+
 import json
 
 import core
@@ -70,10 +77,10 @@ class ParseBase(object):
         url = uri if uri.startswith(API_ROOT) else cls.ENDPOINT_ROOT + uri
         data = kw and json.dumps(kw) or "{}"
         if http_verb == 'GET' and data:
-            url += '?%s' % urllib.urlencode(kw)
+            url += '?%s' % urlencode(kw)
             data = None
 
-        request = urllib2.Request(url, data, headers)
+        request = Request(url, data, headers)
         request.add_header('Content-type', 'application/json')
         request.add_header('X-Parse-Application-Id', app_id)
         request.add_header('X-Parse-REST-API-Key', rest_key)
@@ -84,8 +91,8 @@ class ParseBase(object):
         request.get_method = lambda: http_verb
 
         try:
-            response = urllib2.urlopen(request)
-        except urllib2.HTTPError, e:
+            response = urlopen(request)
+        except HTTPError as e:
             exc = {
                 400: core.ResourceRequestBadRequest,
                 401: core.ResourceRequestLoginRequired,

--- a/parse_rest/query.py
+++ b/parse_rest/query.py
@@ -15,6 +15,10 @@ import json
 import collections
 import copy
 
+try:
+    unicode = unicode
+except NameError:
+    unicode = str
 
 class QueryResourceDoesNotExist(Exception):
     '''Query returned no results'''

--- a/parse_rest/tests.py
+++ b/parse_rest/tests.py
@@ -24,6 +24,12 @@ except ImportError:
     sys.exit('You must create a settings_local.py file with APPLICATION_ID, ' \
                  'REST_API_KEY, MASTER_KEY variables set')
 
+try:
+    unicode = unicode
+except NameError:
+    # is python3
+    unicode = str
+
 register(
     getattr(settings_local, 'APPLICATION_ID'),
     getattr(settings_local, 'REST_API_KEY'),
@@ -318,9 +324,9 @@ class TestFunction(unittest.TestCase):
                                            settings_local.MASTER_KEY))
         try:
             subprocess.call(["parse", "deploy"])
-        except OSError, why:
-            print "parse command line tool must be installed " \
-                "(see https://www.parse.com/docs/cloud_code_guide)"
+        except OSError as why:
+            print("parse command line tool must be installed " \
+                "(see https://www.parse.com/docs/cloud_code_guide)")
             self.skipTest(why)
         os.chdir(original_dir)
 


### PR DESCRIPTION
Hi! I was trying to use your library on Python 3.3.X, so I added support for Python3.  Then I realised that the parse command was written in python2.x.  Anyway, I think that this might help for the future.
