### PR TITLE
Add, Remove, and query Relations

### DIFF
--- a/parse_rest/datatypes.py
+++ b/parse_rest/datatypes.py
@@ -367,3 +367,25 @@ class Object(ParseResource):
             }
         self.__class__.PUT(self._absolute_url, **payload)
         self.__dict__[key] += amount
+
+    def removeRelation(self, key, className, objectsId):
+        self.manageRelation('RemoveRelation', key, className, objectsId)
+
+    def addRelation(self, key, className, objectsId):
+        self.manageRelation('AddRelation', key, className, objectsId)
+
+    def manageRelation(self, action, key, className, objectsId):
+        objects = [{
+                    "__type": "Pointer",
+                    "className": className,
+                    "objectId": objectId
+                    } for objectId in objectsId]
+        
+        payload = {
+            key: {
+                 "__op": action,
+                 "objects": objects
+                }
+            }
+        self.__class__.PUT(self._absolute_url, **payload)
+        self.__dict__[key] = ''

--- a/parse_rest/query.py
+++ b/parse_rest/query.py
@@ -77,7 +77,7 @@ class Queryset(object):
     __metaclass__ = QuerysetMetaclass
 
     OPERATORS = [
-        'lt', 'lte', 'gt', 'gte', 'ne', 'in', 'nin', 'exists', 'select', 'dontSelect', 'all'
+        'lt', 'lte', 'gt', 'gte', 'ne', 'in', 'nin', 'exists', 'select', 'dontSelect', 'all', 'relatedTo'
         ]
 
     @staticmethod
@@ -123,7 +123,10 @@ class Queryset(object):
             if operator is None:
                 self._where[attr] = parse_value
             else:
-                self._where[attr]['$' + operator] = parse_value
+                if operator == 'relatedTo':
+                    self._where['$' + operator] = parse_value
+                else:    
+                    self._where[attr]['$' + operator] = parse_value
         return self
 
     def order_by(self, order, descending=False):


### PR DESCRIPTION
We've added two method to Object class in order to manage relations.
With this changes we can add and remove relations with the following syntax:
object.addRelation(key, className, objectsId)
or 
object.removeRelation(key, className, objectsId)

We also can perform relational queries with Queryset using the key "relatedTo". ie.
comments = Comment.Query.filter(object__relatedTo={"object":{"__type":"Pointer","className":"Product","objectId":product.objectId},"key":"comments"})
