### PR TITLE
Add emailVerified to protected_attributes

### DIFF
--- a/parse_rest/user.py
+++ b/parse_rest/user.py
@@ -35,7 +35,7 @@ class User(ParseResource):
     '''
     ENDPOINT_ROOT = '/'.join([API_ROOT, 'users'])
     PROTECTED_ATTRIBUTES = ParseResource.PROTECTED_ATTRIBUTES + [
-        'username', 'sessionToken']
+        'username', 'sessionToken', 'emailVerified']
 
     def is_authenticated(self):
         return self.sessionToken is not None


### PR DESCRIPTION
Without this change, you will not be able to save users with getting an error code":105,"error":"the emailVerified key is a reserved word.
