### PR TITLE
Fixing buggy interaction with Cloud Code

### DIFF
--- a/parse_rest/datatypes.py
+++ b/parse_rest/datatypes.py
@@ -390,4 +390,3 @@ class Object(ParseResource):
             }
         self.__class__.PUT(self._absolute_url, **payload)
         self.__dict__[key] = ''
-


### PR DESCRIPTION
Without the new line of code, when updating a class that has a file and a "BeforeSave" cloudcode method you generate the following error:

parse_rest.core.ResourceRequestBadRequest: {"code":141,"error":"Uncaught Tried to save an object containing an unsaved file."}.

This change fixes the problem.

Let me know if you have any questions.
