### PR TITLE
Make the relatedTo query work correctly with the Parse REST API.

### DIFF
--- a/parse_rest/query.py
+++ b/parse_rest/query.py
@@ -126,7 +126,7 @@ class Queryset(object):
             if operator is None:
                 q._where[attr] = parse_value
             elif operator == 'relatedTo':
-                q._where['$' + operator] = parse_value
+                q._where['$' + operator] = {'object': parse_value, 'key' : attr }
             else:
                 if not isinstance(q._where[attr], dict):
                     q._where[attr] = {}


### PR DESCRIPTION
There is a bug in the relatedTo query.