### PR TITLE
ParseResource's need to know they've been loaded

### DIFF
--- a/parse_rest/datatypes.py
+++ b/parse_rest/datatypes.py
@@ -237,6 +237,7 @@ class ParseResource(ParseBase):
     def _init_attrs(self, args):
         for key, value in six.iteritems(args):
             setattr(self, key, ParseType.convert_from_parse(value))
+        self._is_loaded = True
 
     def _to_native(self):
         return ParseType.convert_to_parse(self)


### PR DESCRIPTION
In **getattr** we check to see if the object has been lazy loaded or not
before we try to do attribute lookups. However, once the attributes have
been loaded, we never record that.

So this changes _init_attrs, which actually does the loading, to record
that it's done so.

This change took a loop I had that was taking 8-10s to finish down to
.5-1s.
