### PR TITLE
Enable Session Tokens to be used to access ACL protected objects.

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -496,4 +496,22 @@ admin_role.save()
 
 This, for example, creates a role with the name 'moderators', with an ACL that allows the public to read but not write to this role object.
 
+
+Session Tokens
+---------------
+When querying or updating an object protected by an ACL, parse.com requires the session token of the user with read and write privileges, respectively. You can pass the session token to such queries and updates by using the 'parse_rest.connection.SessionToken' class.
+
+~~~~~ {python}
+from parse_rest.connection import SessionToken
+from parse_rest.user import User
+
+u = User.login('dhelmet', '12345')
+token = u.sessionToken
+
+with SessionToken(token):
+    collectedItem = CollectedItem.Query.get(type="Sword") # Get a collected item, Sword, that is protected by ACL
+    print collectedItem
+~~~~~
+
+
 That's it! This is a first try at a Python library for Parse, and is probably not bug-free. If you run into any issues, please get in touch -- dgrtwo@princeton.edu. Thanks!

--- a/README.mkd
+++ b/README.mkd
@@ -499,7 +499,7 @@ This, for example, creates a role with the name 'moderators', with an ACL that a
 
 Session Tokens
 ---------------
-When querying or updating an object protected by an ACL, parse.com requires the session token of the user with read and write privileges, respectively. You can pass the session token to such queries and updates by using the 'parse_rest.connection.SessionToken' class.
+When querying or updating an object protected by an ACL, parse.com requires the session token of the user with read and write privileges, respectively. You can pass the session token to such queries and updates by using the `parse_rest.connection.SessionToken` class.
 
 ~~~~~ {python}
 from parse_rest.connection import SessionToken

--- a/README.mkd
+++ b/README.mkd
@@ -513,5 +513,7 @@ with SessionToken(token):
     print collectedItem
 ~~~~~
 
+Assuming the CollectedItem, 'Sword', is read-protected from the public by an ACL and is readable only by the user, SessionToken allows the user to bypass the ACL and get the 'Sword' item.
+
 
 That's it! This is a first try at a Python library for Parse, and is probably not bug-free. If you run into any issues, please get in touch -- dgrtwo@princeton.edu. Thanks!

--- a/README.mkd
+++ b/README.mkd
@@ -513,7 +513,7 @@ with SessionToken(token):
     print collectedItem
 ~~~~~
 
-Assuming the CollectedItem, 'Sword', is read-protected from the public by an ACL and is readable only by the user, SessionToken allows the user to bypass the ACL and get the 'Sword' item.
+Assuming the CollectedItem 'Sword' is read-protected from the public by an ACL and is readable only by the user, SessionToken allows the user to bypass the ACL and get the 'Sword' item.
 
 
 That's it! This is a first try at a Python library for Parse, and is probably not bug-free. If you run into any issues, please get in touch -- dgrtwo@princeton.edu. Thanks!

--- a/parse_rest/connection.py
+++ b/parse_rest/connection.py
@@ -35,6 +35,18 @@ def register(app_id, rest_key, **kw):
     ACCESS_KEYS.update(**kw)
 
 
+class SessionToken:
+    def __init__(self, token):
+        global ACCESS_KEYS
+        self.token = token
+
+    def __enter__(self):
+        ACCESS_KEYS.update({'session_token': self.token})
+
+    def __exit__(self, type, value, traceback):
+        ACCESS_KEYS['session_token']
+
+
 def master_key_required(func):
     '''decorator describing methods that require the master key'''
     def ret(obj, *args, **kw):
@@ -89,6 +101,9 @@ class ParseBase(object):
         headers.update(extra_headers or {})
 
         request = Request(url, data, headers)
+        
+        if ACCESS_KEYS.get('session_token'):
+            request.add_header('X-Parse-Session-Token', ACCESS_KEYS.get('session_token'))
 
         if master_key and 'X-Parse-Session-Token' not in headers.keys():
             request.add_header('X-Parse-Master-Key', master_key)


### PR DESCRIPTION
This enables session token support by creating a context manager SessionToken which takes a user's session token as an argument and includes it in the header sent to parse.com, allowing queries and saves to ACL protected objects. Thanks to [jimmyho](https://github.com/dgrtwo/ParsePy/issues/74) for getting this started.