### PR TITLE
User.current_user() when a valid session token is provided

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -391,6 +391,26 @@ u.save()
 u.delete()
 ~~~~~
 
+To get the current user from a Parse session:
+
+~~~~~ {python}
+from parse_rest.connection import SessionToken, register
+
+# Acquire a valid parse session somewhere
+# Example: token = request.session.get('session_token')
+
+# Method 1: Using a `with` statement
+# Do this to isolate use of session token in this block only
+with SessionToken(token):
+    me = User.current_user()
+
+# Method 2: register your parse connection with `session_token` parameter
+# Do this to use the session token for all subsequent queries
+register(PARSE_APPID, PARSE_APIKEY, session_token=token)
+me = User.current_user()
+~~~~~
+
+
 Push
 ---------------
 

--- a/README.mkd
+++ b/README.mkd
@@ -54,8 +54,11 @@ in the app and may accidentally replace or change existing objects.
 
 You can then test the installation by running the following command:
 
-    python -m 'parse_rest.tests'
+    # test all
+    python -m unittest parse_rest.tests
 
+    # or test individually
+    python -m unittest parse_rest.tests.TestObject.testCanCreateNewObject
 
 Usage
 -----------

--- a/parse_rest/tests.py
+++ b/parse_rest/tests.py
@@ -507,6 +507,21 @@ class TestUser(unittest.TestCase):
         g.save()
         self.assertEqual(1, len(Game.Query.filter(creator=user)))
 
+    def testCanGetCurrentUser(self):
+        user = User.signup(self.username, self.password)
+        self.assertIsNotNone(user.sessionToken)
+
+        register(
+            getattr(settings_local, 'APPLICATION_ID'),
+            getattr(settings_local, 'REST_API_KEY'),
+            session_token=user.sessionToken
+        )
+
+        current_user = User.current_user()
+        self.assertIsNotNone(current_user)
+        self.assertEqual(current_user.sessionToken, user.sessionToken)
+        self.assertEqual(current_user.username, user.username)
+
 
 class TestPush(unittest.TestCase):
     """

--- a/parse_rest/user.py
+++ b/parse_rest/user.py
@@ -91,6 +91,11 @@ class User(ParseResource):
         login_url = User.ENDPOINT_ROOT
         return cls(**User.POST(login_url, authData=auth))
 
+    @classmethod
+    def current_user(cls):
+        user_url = '/'.join([API_ROOT, 'users/me'])
+        return cls(**User.GET(user_url))
+
     @staticmethod
     def request_password_reset(email):
         '''Trigger Parse\'s Password Process. Return True/False


### PR DESCRIPTION
This is equivalent to Parse.User.current_user() in other platforms. By providing a valid session token (from a session cookie or other means), the current user can be extracted from it.

This would also be useful for verifying a user session token. See [Parse Documentation](https://www.parse.com/docs/rest#users-validating).