### PR TITLE
Revert "Set an ACL on ParseResource by default"

### DIFF
--- a/parse_rest/datatypes.py
+++ b/parse_rest/datatypes.py
@@ -255,8 +255,6 @@ class ACL(ParseType):
 
     def __init__(self, acl=None):
         self._acl = acl or {}
-        if acl is None:
-            self.set_default(read=True, write=True)
 
     def _to_native(self):
         return self._acl
@@ -319,8 +317,6 @@ class ParseResource(ParseBase):
     def __init__(self, **kw):
         self.objectId = None
         self._init_attrs(kw)
-        if 'ACL' not in kw:
-            self.ACL = ACL()
 
     def __getattr__(self, attr):
         # if object is not loaded and attribute is missing, try to load it


### PR DESCRIPTION
A default ACL breaks the unit tests for Users (since Users cannot be writeable by other users). It also breaks other functionality--if there are default global read/write permissions, using set_role or set_user won't override it, which is a security risk. We may want to look at other ways to prevent the difficulty mentioned in issue #97, but for now, it's probably best to do what other SDKs do and not have an ACL until the user creates one (and have an ACL created with no arguments result in master-key-only permissions, rather than global read/write permissions).

Closes #97