### PR TITLE
Added Remove Field support on Object, including tests

### DIFF
--- a/parse_rest/datatypes.py
+++ b/parse_rest/datatypes.py
@@ -455,6 +455,19 @@ class Object(six.with_metaclass(ObjectMetaclass, ParseResource)):
             }
         self.__class__.PUT(self._absolute_url, **payload)
         self.__dict__[key] += amount
+        
+    def remove(self, key):
+        """
+        Clear a column value in the object. Note that this happens immediately:
+        it does not wait for save() to be called.
+        """
+        payload = {
+            key: {
+                '__op': 'Delete'
+                }
+            }
+        self.__class__.PUT(self._absolute_url, **payload)
+        del self.__dict__[key]
 
     def removeRelation(self, key, className, objectsId):
         self.manageRelation('RemoveRelation', key, className, objectsId)

--- a/parse_rest/tests.py
+++ b/parse_rest/tests.py
@@ -143,6 +143,13 @@ class TestObject(unittest.TestCase):
         self.score.increment('score')
         self.assertTrue(GameScore.Query.filter(score=previous_score + 1).exists(),
                      'Failed to increment score on backend')
+                     
+    def testCanRemoveField(self):
+        self.score.save()
+        self.score.remove('score')
+        self.assertTrue(GameScore.Query.filter(score=None).exists(),
+                     'Failed to remove score on backend')
+
 
     def testAssociatedObject(self):
         """test saving and associating a different object"""

--- a/parse_rest/tests.py
+++ b/parse_rest/tests.py
@@ -150,7 +150,6 @@ class TestObject(unittest.TestCase):
         self.assertTrue(GameScore.Query.filter(score=None).exists(),
                      'Failed to remove score on backend')
 
-
     def testAssociatedObject(self):
         """test saving and associating a different object"""
 


### PR DESCRIPTION
The parse REST API does support the `__op` `Delete` to clear a field data, In this pull request I added a method similar to `increment`, named `remove`, to remove a field from the row. Also added a test to test it.

It has been tested (using the tests.py) and it is working.