### PR TITLE
Suport regex query-constrains

### DIFF
--- a/parse_rest/query.py
+++ b/parse_rest/query.py
@@ -65,7 +65,7 @@ class QueryManager(object):
 class Queryset(object):
 
     OPERATORS = [
-        'lt', 'lte', 'gt', 'gte', 'ne', 'in', 'nin', 'exists', 'select', 'dontSelect', 'all', 'relatedTo', 'nearSphere'
+        'lt', 'lte', 'gt', 'gte', 'ne', 'in', 'nin', 'exists', 'select', 'dontSelect', 'all', 'regex', 'relatedTo', 'nearSphere'
     ]
 
     @staticmethod


### PR DESCRIPTION
Because queries-constraints of "regex" was added to ParseAPI, I added it to a list.

* https://www.parse.com/docs/rest/guide/#queries-constraints