### PR TITLE
Added automatic conversion of array of pointers to parse object 

### DIFF
--- a/parse_rest/datatypes.py
+++ b/parse_rest/datatypes.py
@@ -35,6 +35,8 @@ class ParseType(object):
 
     @staticmethod
     def convert_from_parse(parse_key, parse_data):
+        if isinstance(parse_data, list):
+            return [ParseType.convert_from_parse(parse_key, item) for item in parse_data]
 
         parse_type = None
         if isinstance(parse_data, dict):
@@ -455,7 +457,7 @@ class Object(six.with_metaclass(ObjectMetaclass, ParseResource)):
             }
         self.__class__.PUT(self._absolute_url, **payload)
         self.__dict__[key] += amount
-        
+
     def remove(self, key):
         """
         Clear a column value in the object. Note that this happens immediately:

--- a/parse_rest/tests.py
+++ b/parse_rest/tests.py
@@ -359,6 +359,19 @@ class TestQuery(unittest.TestCase):
         self.assertTrue(score.game.objectId)
         #nice to have - also check no more then one query is triggered
 
+    def testSelectRelatedArray(self):
+        scores = GameScore.Query.all()
+        game = Game.Query.all().limit(1)[0]
+
+        game.score_array = scores
+        game.save() # Saved an array of pointers in the game
+
+        game = Game.Query.filter(objectId=game.objectId).select_related('score_array')[0]
+        for score in game.score_array:
+            self.assertIsInstance(score, GameScore)
+            self.assertEqual(score.player_name, 'John Doe') # This would trigger a GET if select_related were not used.
+        #nice to have - also check no more then one query is triggered
+
     def testCanCompareDateInequality(self):
         today = datetime.datetime.today()
         tomorrow = today + datetime.timedelta(days=1)


### PR DESCRIPTION
Before this patch, an Array of Pointers in the Parse.com database would be converted to an list of dicts in the Python object. Now it will be converted to a list of Parse Objects.

It also works fine with `select_related`: when iterating over the list, a GET will be issued for each item, unless `select_related` was used, in the last scenario all objects within the Array will be received on the single query. 

This is the same behaviour observed on the official Parse API for the other languages.