### PR TITLE
work with self-hosted parse server

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,3 +1,15 @@
+about the fork
+=========
+
+- Forked from https://github.com/dgrtwo/ParsePy on 3/28 by @milesrichardson
+- upstream seems to be no longer maintained
+- major fixes in fork:
+  - (improvement) Work with self-hosted parse-server
+  - (improvement) Work with self-hosted parse-server and batch_save
+  - (bugfix) batch_save calls response callback on ALL responses, even if some contain errors, and raises ParseBatchError([error1, error2, error3]) with list of all errors encountered during batch operation
+
+(See https://github.com/dgrtwo/ParsePy/pull/138 for PR)
+
 parse_rest
 ==========
 
@@ -560,7 +572,7 @@ Assuming the CollectedItem 'Sword' is read-protected from the public by an ACL a
 
 Elevating Access to Master
 --------------------------
-Sometimes it is useful to only allow privileged use of the master key for specific uses. 
+Sometimes it is useful to only allow privileged use of the master key for specific uses.
 
 ~~~~~ {python}
 from parse_rest.connection import MasterKey

--- a/parse_rest/connection.py
+++ b/parse_rest/connection.py
@@ -19,7 +19,9 @@ import json
 
 from parse_rest import core
 
-API_ROOT = 'https://api.parse.com/1'
+import os
+API_ROOT=os.environ.get('PARSE_API_ROOT')
+
 ACCESS_KEYS = {}
 
 
@@ -118,7 +120,7 @@ class ParseBase(object):
         headers.update(extra_headers or {})
 
         request = Request(url, data, headers)
-        
+
         if ACCESS_KEYS.get('session_token'):
             request.add_header('X-Parse-Session-Token', ACCESS_KEYS.get('session_token'))
         elif master_key:

--- a/parse_rest/connection.py
+++ b/parse_rest/connection.py
@@ -189,10 +189,10 @@ class ParseBatcher(ParseBase):
             if "success" in response:
                 callback(response["success"])
             else:
-                batched_errors.append(core.ParseError(response["error"]))
+                batched_errors.append(response["error"])
 
         if batched_errors:
-            raise batched_errors[0]
+            raise core.ParseBatchError(batched_errors)
 
     def batch_save(self, objects):
         """save a list of objects in one operation"""

--- a/parse_rest/connection.py
+++ b/parse_rest/connection.py
@@ -20,7 +20,8 @@ import json
 from parse_rest import core
 
 import os
-API_ROOT=os.environ.get('PARSE_API_ROOT')
+
+API_ROOT = os.environ.get('PARSE_API_ROOT') or 'https://api.parse.com/1'
 
 ACCESS_KEYS = {}
 

--- a/parse_rest/core.py
+++ b/parse_rest/core.py
@@ -16,6 +16,9 @@ class ParseError(Exception):
     '''Base exceptions from requests made to Parse'''
     pass
 
+class ParseBatchError(Exception):
+    ''' Error in batching operation... should take a list. '''
+    pass
 
 class ResourceRequestBadRequest(ParseError):
     '''Request returns a 400'''


### PR DESCRIPTION
Major fixes:

1. (improvement) Work with self-hosted parse-server
2. (improvement) Work with self-hosted parse-server and `batch_save`
3. (bugfix) `batch_save` calls response callback on ALL responses, even if some contain errors, and raises `ParseBatchError([error1, error2, error3])` with list of all errors encountered during batch operation

The similar pull request from @basilfamer (#136) does NOT work with self-hosted parse-server, because it changes the value of `API_ROOT` after other classes have already set their class properties to the old `API_ROOT`, and because it does not support batch_saving (which depends on `parse.com` in the URL).

My pull request uses an environment variable. If you want to use self hosted parse server, it's this simple:

```python
    import os
    os.environ["PARSE_API_ROOT"] = "http://your_server.com:1337/parse"

    # Everything else same as usual

    from parse_rest.datatypes import Function, Object, GeoPoint
    from parse_rest.connection import register
    from parse_rest.query import QueryResourceDoesNotExist
    from parse_rest.connection import ParseBatcher
    from parse_rest.core import ResourceRequestBadRequest, ParseError

    APPLICATION_ID = '...'
    REST_API_KEY = '...'
    MASTER_KEY = '...'

    register(APPLICATION_ID, REST_API_KEY, master_key=MASTER_KEY)
```

(If you want to use regular parse.com, just don't set the environment variable, and it will default to parse.com.)

Batch saving/deleting is also supported on self-hosted parse-server.

I also fixed a bug in batching. Previously, when performing `batch_save` on multiple objects, if just ONE of them failed, then the "response callback" for all objects after it would never execute. The result of this is that if you `batch_save` 10 objects, and the first 1 of them failed, then the "callback" would not execute on the remaining 9 objects. So for example if you were relying on that callback to set the `objectId` of saved objects, then NONE of the objects in the list would have their `objectId` set, even though they saved correctly.

Now, any errors encountered in a batch operation are appended to a list, and when the batch operation completes, if there were any errors it raises a `ParseBatchError` exception (child of `ParseError`) with `.message` set to the list of errors. For example:

```python
# Batch save a list of two objects:
#   dupe_object is a duplicate violating a unique key constraint
#   dupe_object2 is a duplicate violating a unique key constraint
#   new_object is a new object satisfying the unique key constraint
#
# dupe_object and dupe_object2 will fail to save, and new_object will save successfully

dupe_object = list(MyClass.Query.all().limit(2))[0]
dupe_object2 = list(MyClass.Query.all().limit(2))[1]
new_object = MyClass(some_column=11111)
objects = [dupe_object + new_object]

batcher = ParseBatcher()
batcher.batch_save(objects)
```

Will raise exception (note the LIST of two errors)

```python

Traceback (most recent call last):
  File "<console>", line 1, in <module>
  File "/Users/miles/ParsePy/parse_rest/connection.py", line 199, in batch_save
    self.batch(o.save for o in objects)
  File "/Users/miles/ParsePy/parse_rest/connection.py", line 195, in batch
    raise core.ParseBatchError(batched_errors)

ParseBatchError: [{u'code': 11000, u'error': u'E11000 duplicate key error index: myapp.MyClass.$my_column_1 dup key: { : 555555 }'}, {u'code': 11000, u'error': u'E11000 duplicate key error index: myapp.MyClass.$my_column_1 dup key: { : 44444 }'}]
```

And CRUCIALLY, the `objectId` field of the NON-duplicate object will be correctly set:

````python
>>> #batch_save as above...
>>> print objects
[<MyClass:gOHuhPbGZJ>, <MyClass:None>, <MyClass:None>]
```

Whereas prior to my pull request, NONE of the objects would have `objectId` after saving, even though one of them saved correctly:

````python
>>> #batch_save as above...
>>> print objects
[<MyClass:None>, <MyClass:None>, <MyClass:None>]
```

